### PR TITLE
Fix default int value

### DIFF
--- a/app/helper/data_helper.go
+++ b/app/helper/data_helper.go
@@ -34,12 +34,8 @@ func IsEmptyValue(v interface{}) bool {
 		return val == 0
 	case *int:
 		return val == nil
-	case *int64:
-		return val == nil
 	case int64:
 		return val == 0
-	case *float64:
-		return val == nil
 	case float64:
 		return val == 0
 	case *time.Time:

--- a/app/helper/data_helper.go
+++ b/app/helper/data_helper.go
@@ -32,8 +32,14 @@ func IsEmptyValue(v interface{}) bool {
 		return val == ""
 	case int:
 		return val == 0
+	case *int:
+		return val == nil
+	case *int64:
+		return val == nil
 	case int64:
 		return val == 0
+	case *float64:
+		return val == nil
 	case float64:
 		return val == 0
 	case *time.Time:

--- a/cmd/domain/main.go
+++ b/cmd/domain/main.go
@@ -150,7 +150,6 @@ func parseExtraFields(
 		}
 
 		fieldName := SnakeToCamel(colName)
-		fieldLines = append(fieldLines, fmt.Sprintf("%s %s %s", fieldName, goType, tag))
 		colNames = append(colNames, fmt.Sprintf("\"%s\"", colName))
 		valNames = append(valNames, fmt.Sprintf("m.%s", fieldName))
 		schemaMap = append(schemaMap, fmt.Sprintf("\"%s\": \"%s\"", colName, goSchemaType))
@@ -162,7 +161,13 @@ func parseExtraFields(
 
 		if strings.Contains(upperLine, "DEFAULT") {
 			defaultCols = append(defaultCols, fmt.Sprintf("\"%s\"", colName))
+
+			if goType != "string" {
+				goType = "*" + goType
+			}
 		}
+
+		fieldLines = append(fieldLines, fmt.Sprintf("%s %s %s", fieldName, goType, tag))
 	}
 
 	fields = strings.Join(fieldLines, "\n\t")

--- a/cmd/domain/main.go
+++ b/cmd/domain/main.go
@@ -162,7 +162,7 @@ func parseExtraFields(
 		if strings.Contains(upperLine, "DEFAULT") {
 			defaultCols = append(defaultCols, fmt.Sprintf("\"%s\"", colName))
 
-			if goType != "string" {
+			if goType == "int" {
 				goType = "*" + goType
 			}
 		}

--- a/tests/unit/helper/data_helper_test.go
+++ b/tests/unit/helper/data_helper_test.go
@@ -78,6 +78,7 @@ func TestFilterJSON_EmptyFieldsSlice(t *testing.T) {
 func TestIsEmptyValue_Types(t *testing.T) {
 	now := time.Now()
 	jsonTime := helper.JSONTime(now)
+	intVal := 0
 
 	tt := []struct {
 		name  string
@@ -100,6 +101,9 @@ func TestIsEmptyValue_Types(t *testing.T) {
 
 		{"*time.Time nil", (*time.Time)(nil), true},
 		{"*time.Time non-nil", &now, false},
+
+		{"*int nil", (*int)(nil), true},
+		{"*int non-nil", &intVal, false},
 
 		{"*JSONTime nil", (*helper.JSONTime)(nil), true},
 		{"*JSONTime non-nil", &jsonTime, false},
@@ -286,6 +290,26 @@ func TestBuildRowTokens_DefaultNonEmptyPointer(t *testing.T) {
 	}
 	if !reflect.DeepEqual(args, wantArgs) {
 		t.Errorf("BuildRowTokens default non-empty pointer: got args %v, want %v", args, wantArgs)
+	}
+}
+
+func TestBuildRowTokens_DefaultNilIntPointer(t *testing.T) {
+	var score *int
+
+	allCols := []string{"name", "score"}
+	vals := []interface{}{"item", score}
+	defaultCols := []string{"score"}
+
+	rowSQL, args := helper.BuildRowTokens(allCols, vals, defaultCols)
+
+	wantSQL := "(?, DEFAULT)"
+	wantArgs := []interface{}{"item"}
+
+	if rowSQL != wantSQL {
+		t.Errorf("BuildRowTokens default nil int pointer: got SQL %q, want %q", rowSQL, wantSQL)
+	}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("BuildRowTokens default nil int pointer: got args %v, want %v", args, wantArgs)
 	}
 }
 


### PR DESCRIPTION
### Problem

My field **Status** in database have default value 1. Ex: **status TINYINT DEFAULT 1 COMMENT '0 = draft, 1 = active'**.

If I send value zero, will be filtered and without this column, database will use default value. So my register can't start like draft.

### Solution

For every int, int64 and float64 field that **HAVE** default value, we will implement using pointer. If we not send this value in the struct, database will use default value. Ex:

```shell
{
    "name": "Test"
}
``` 
If user send any value (include zero) we will use this value. Ex:

```shell
{
    "name": "Test",
    "status": 0 // or 1, 2, 3, 4
}
``` 